### PR TITLE
Use a default delimiter

### DIFF
--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -52,7 +52,12 @@ Notifier.prototype.add_box = function(box, cb, debug) {
     delete self.errors[box]
     self.logger.info({box: box}, 'Connected to server')
     self.logger.info({box: box},'Selecting box');
-    var delimiter = connection.namespaces.personal[0].delimiter;
+
+    var delimiter = '/';
+    if (connection.namespaces) {
+      delimiter = connection.namespaces.personal[0].delimiter;
+    }
+
     connection.openBox(replace(box, '/', delimiter), true, function(err) {
       if (err) throw err;
       connection.on('mail', function() {


### PR DESCRIPTION
in case when connection.namespaces is undefined. In my case this
happened when I connected to a local
davmail-server (http://davmail.sourceforge.net/)
