### PR TITLE
Feature sync on del

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # imapnotify
 
-Execute scripts on new messages using IDLE IMAP command
+Execute scripts on IMAP mailbox changes (new/deleted/updated messages) using IDLE.
 
 # config
 
@@ -12,8 +12,8 @@ Execute scripts on new messages using IDLE IMAP command
   "tlsOptions": { "rejectUnauthorized": false },
   "username": "",
   "password": "",
-  "onNewMail": "/usr/bin/mbsync test-%s",
-  "onNewMailPost": "/usr/bin/notmuch new",
+  "onNotify": "/usr/bin/mbsync test-%s",
+  "onNotifyPost": "/usr/bin/notmuch new",
   "boxes":
     [
       "box1",
@@ -23,8 +23,8 @@ Execute scripts on new messages using IDLE IMAP command
 ```
 
 ```
-    onNewMail: an executable to run on new mail in box
-    onNewPost: an executable to run after onNewMail command
+    onNotify: an executable to run on new mail in box
+    onNotifyPost: an executable to run after onNotify command
 ```
 
 ### extra options
@@ -74,8 +74,8 @@ follows.  Assuming the script ~/getpass.sh prints out your password.
     exports.tlsOptions = { "rejectUnauthorized": false };
     exports.username = "<user>";
     exports.password = getStdout("~/getpass.sh");
-    exports.onNewMail = "<sync command>"
-    exports.onNewMailPost = "<command>"
+    exports.onNotify = "<sync command>"
+    exports.onNotifyPost = "<command>"
     exports.boxes = [ "box1", "box2", "some/other/box" ];
 ```
 
@@ -88,7 +88,7 @@ Thanks Matthew, for pointing that out!
 
 ## substitutions
 
-`%s` in `onNewMail` and `onNewMailPost` is replaced by the box name.
+`%s` in `onNotify` and `onNotifyPost` is replaced by the box name.
 
 `/` symbol (slash) is replaced by `-` symbol (minus) so that
 `inbox/junk` becomes `inbox-junk`

--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -64,6 +64,14 @@ Notifier.prototype.add_box = function(box, cb, debug) {
         self.logger.info({box: box}, 'New mail')
         cb(box)
       })
+      connection.on('expunge', function() {
+        self.logger.info({box: box}, 'Messages deleted')
+        cb(box)
+      })
+      connection.on('update', function() {
+        self.logger.info({box: box}, 'Messages deleted')
+        cb(box)
+      })
     });
   });
 

--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -65,11 +65,11 @@ Notifier.prototype.add_box = function(box, cb, debug) {
         cb(box)
       })
       connection.on('expunge', function() {
-        self.logger.info({box: box}, 'Messages deleted')
+        self.logger.info({box: box}, 'Deleted messages')
         cb(box)
       })
       connection.on('update', function() {
-        self.logger.info({box: box}, 'Messages deleted')
+        self.logger.info({box: box}, 'Altered message metadata')
         cb(box)
       })
     });

--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -51,7 +51,7 @@ Notifier.prototype.add_box = function(box, cb, debug) {
   connection.once('ready', function() {
     delete self.errors[box]
     self.logger.info({box: box}, 'Connected to server')
-    self.logger.info({box: box},'Selecting box');
+    self.logger.info({box: box}, 'Selecting box');
 
     var delimiter = '/';
     if (connection.namespaces) {
@@ -60,18 +60,15 @@ Notifier.prototype.add_box = function(box, cb, debug) {
 
     connection.openBox(replace(box, '/', delimiter), true, function(err) {
       if (err) throw err;
-      connection.on('mail', function() {
-        self.logger.info({box: box}, 'New mail')
-        cb(box)
-      })
-      connection.on('expunge', function() {
-        self.logger.info({box: box}, 'Deleted messages')
-        cb(box)
-      })
-      connection.on('update', function() {
-        self.logger.info({box: box}, 'Altered message metadata')
-        cb(box)
-      })
+      function addConnectionListener(event, message) {
+        connection.on(event, function() {
+          self.logger.info({box: box}, message)
+          cb(box)
+        })
+      }
+      addConnectionListener('mail',    'New Mail')
+      addConnectionListener('expunge', 'Deleted Mail')
+      addConnectionListener('update',  'Altered message metadata')
     });
   });
 
@@ -109,7 +106,7 @@ Notifier.prototype.add_box = function(box, cb, debug) {
   connection.once('shouldReconnect', function() {
     self.logger.debug({box: box}, 'shouldReconnect event')
     self.logger.debug({box: box}, 'Reading box')
-    self.add_box(box, executeOnNewMail(self.config), process.env['DEBUG'] === 'imap' ? logger.debug : null)
+    self.add_box(box, executeOnNotify(self.config), process.env['DEBUG'] === 'imap' ? logger.debug : null)
     self.start_watch(box)
   })
 }
@@ -234,9 +231,9 @@ function executeCommands(command, postCommand, cb) {
   })
 }
 
-function executeOnNewMail(config) {
-  var command = config.onNewMail
-    , postCommand = config.onNewMailPost
+function executeOnNotify(config) {
+  var command = config.onNotify || config.onNewMail
+    , postCommand = config.onNotifyPost || config.onNewMailPost
   ;
   return function notify(box) {
       box = replace(box.toLowerCase(), '\/', '-')
@@ -276,7 +273,7 @@ function main(cb) {
   var notifier = new Notifier(config);
 
   config.boxes.forEach(function (box) {
-    notifier.add_box(box, executeOnNewMail(config), process.env['DEBUG'] === 'imap' ? logger.debug : null)
+    notifier.add_box(box, executeOnNotify(config), process.env['DEBUG'] === 'imap' ? logger.debug : null)
   })
 
   process.on('SIGINT', function() {


### PR DESCRIPTION
Per Issue #13.

* Triggers sync script not only on new mail, but also on deleted and altered messages. 
* Updates config variables `onNewMail`/`onNewMailPost` to `onNotify`/`onNotifyPost` to reflect this change, but supports the originals for backwards compatibility.
* Updates README to reflect changes.