### PR TITLE
Fix post command execution

### DIFF
--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -240,7 +240,7 @@ function executeOnNotify(config) {
 	return function notify(box, event) {
 		var formattedBox = replace(box.toLowerCase(), '/', '-')
 		, formattedCommand = printf(commandIsEventMap ? command[event] || '': command, formattedBox)
-		, formattedPostCommand = printf(postCommandIsEventMap ? postCommand[event] || '': command, formattedBox)
+		, formattedPostCommand = printf(postCommandIsEventMap ? postCommand[event] || '': postCommand, formattedBox)
 		return executeCommands(formattedCommand, formattedPostCommand)
 	}
 }


### PR DESCRIPTION
Currently, `onNotify` command is executed twice in a row and
`onNotifyPost` is not executed at all. The issue is caused by a type
in the code.

Known workaround: use an object for post command instead of a string.