### PR TITLE
Add support for onStartupIfUnseenMail

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Execute scripts on IMAP mailbox changes (new/deleted/updated messages) using IDL
   "password": "",
   "onNotify": "/usr/bin/mbsync test-%s",
   "onNotifyPost": {"mail": "/usr/bin/notmuch new && notify-send 'New mail arrived'"},
+  "onStartupIfUnseenMail": "/usr/bin/mbsync test-%s",
+  "onStartupIfUnseenMailPost": "/usr/bin/notmuch new && notify-send 'New mail available'",
   "boxes":
     [
       "box1",
@@ -30,7 +32,11 @@ Execute scripts on IMAP mailbox changes (new/deleted/updated messages) using IDL
     onNotifyPost:
 		[string]: shell command to run after onNotify event
 		[object]: shell commands to run after onNotify for each type of event
-			keys: "mail" for new mail, "update" for existing messages updates, "expunge" for messages deletions
+			keys: "mail" for new mail, "update" for existing messages updates,
+      "expunge" for messages deletions
+    onStartupIfUnseenMail: shell command to run if unseen mail is available when connecting
+    onStartupIfUnseenMailPost: shell command to run after the previous one, when
+    unseen mail is available
 ```
 
 ### extra options
@@ -82,6 +88,8 @@ follows.  Assuming the script ~/getpass.sh prints out your password.
     exports.password = getStdout("~/getpass.sh");
     exports.onNotify = "<sync command>"
     exports.onNotifyPost = "<command>"
+    exports.onStartupIfUnseenMail = "<sync command>"
+    exports.onStartupIfUnseenMailPost = "<command>"
     exports.boxes = [ "box1", "box2", "some/other/box" ];
 ```
 
@@ -94,7 +102,7 @@ Thanks Matthew, for pointing that out!
 
 ## substitutions
 
-`%s` in `onNotify` and `onNotifyPost` is replaced by the box name.
+`%s` in `onNotify`, `onNotifyPost`, `onStartupIfUnseenMail` and `onStartupIfUnseenMailPost` is replaced by the box name.
 
 `/` symbol (slash) is replaced by `-` symbol (minus) so that
 `inbox/junk` becomes `inbox-junk`

--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -35,9 +35,12 @@ function Notifier(config) {
     this.logger = logger.child({'server': this.config.server})
 }
 
-Notifier.prototype.add_box = function(box, cb, debug) {
+Notifier.prototype.add_box = function(box, cb, cbStartup, debug) {
   if (typeof cb !== 'function') {
     cb = function() {}
+  }
+  if (typeof cbStartup !== 'function') {
+      cbStartup = function() {}
   }
   var self = this;
 
@@ -58,7 +61,15 @@ Notifier.prototype.add_box = function(box, cb, debug) {
       delimiter = connection.namespaces.personal[0].delimiter;
     }
 
-    connection.openBox(replace(box, '/', delimiter), true, function(err) {
+    //retrieve status information about the box before opening it
+    connection.status(replace(box, '/', delimiter), function(err, boxStatus) {
+      if (err) throw err;
+      if (boxStatus.messages.unseen > 0) {
+        cbStartup(box);
+      }
+    });
+
+    connection.openBox(replace(box, '/', delimiter), true, function(err, openedBox) {
       if (err) throw err;
       function addConnectionListener(event, message) {
         connection.on(event, function() {
@@ -230,7 +241,17 @@ function executeCommands(command, postCommand, cb) {
     }
   })
 }
-
+function executeOnStartupIfUnseenMail(config) {
+  var command = config.onStartupIfUnseenMail
+  , postCommand = config.onStartupIfUnseenMailPost
+  ;
+  return function notify(box) {
+    box = replace(box.toLowerCase(), '\/', '-')
+    command = printf(command, box)
+    postCommand = printf(postCommand, box)
+    return executeCommands(command, postCommand)
+  }
+}
 function executeOnNotify(config) {
   var command = config.onNotify || config.onNewMail
     , postCommand = config.onNotifyPost || config.onNewMailPost
@@ -275,7 +296,7 @@ function main(cb) {
   var notifier = new Notifier(config);
 
   config.boxes.forEach(function (box) {
-    notifier.add_box(box, executeOnNotify(config), process.env['DEBUG'] === 'imap' ? logger.debug : null)
+    notifier.add_box(box, executeOnNotify(config), executeOnStartupIfUnseenMail(config), process.env['DEBUG'] === 'imap' ? logger.debug : null)
   })
 
   process.on('SIGINT', function() {

--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -261,7 +261,7 @@ function executeOnNotify(config) {
 	return function notify(box, event) {
 		var formattedBox = replace(box.toLowerCase(), '/', '-')
 		, formattedCommand = printf(commandIsEventMap ? command[event] || '': command, formattedBox)
-		, formattedPostCommand = printf(postCommandIsEventMap ? postCommand[event] || '': command, formattedBox)
+    , formattedPostCommand = printf(postCommandIsEventMap ? postCommand[event] || '': postCommand, formattedBox)
 		return executeCommands(formattedCommand, formattedPostCommand)
 	}
 }

--- a/bin/imapnotify
+++ b/bin/imapnotify
@@ -302,7 +302,7 @@ function main(cb) {
   process.on('SIGINT', function() {
     logger.info('Caught Ctrl-C, exiting...')
     notifier.stop(function() {
-      logger.info('imap-inotify stoped')
+      logger.info('imap-inotify stopped')
       runOnSig('INT', config, function() {process.exit(0)})
     })
   })
@@ -310,7 +310,7 @@ function main(cb) {
   process.on('SIGTERM', function() {
     logger.info('Caught SIGTERM, exiting...')
     notifier.stop(function() {
-      logger.info('imap-inotify stoped')
+      logger.info('imap-inotify stopped')
       runOnSig('TERM', config, function() {process.exit(2)})
     })
   })


### PR DESCRIPTION
This adds the possibility to have commands to be ran when we start imapnotify, if there is unseen mail waiting.
This is useful in the case where mail came in when it wasn't monitored by imapnotify (i.e. computer was shut off), and still a notification right at the start for example.